### PR TITLE
Allow using multiple data dirs

### DIFF
--- a/LfMerge.AutomatedSRTests/Settings.cs
+++ b/LfMerge.AutomatedSRTests/Settings.cs
@@ -23,8 +23,16 @@ namespace LfMerge.AutomatedSRTests
 			set { _tempDir = value; }
 		}
 
+		private static string _dataDirName;
+
+		public static string DataDirName
+		{
+			get { return string.IsNullOrEmpty(_dataDirName) ? "data" : _dataDirName; }
+			set { _dataDirName = value; }
+		}
+
 		public static string DataDir =>
-			Path.Combine(FileLocator.DirectoryOfApplicationOrSolution, "data");
+			Path.Combine(FileLocator.DirectoryOfApplicationOrSolution, DataDirName);
 
 		public static void Cleanup()
 		{

--- a/TestUtil/Options.cs
+++ b/TestUtil/Options.cs
@@ -26,6 +26,9 @@ namespace LfMerge.TestUtil
 			[Option("workdir", HelpText = "Where to create/find the test repo")]
 			public string WorkDir { get; set; }
 
+			[Option("datadir", HelpText = "Where to store/find the split-up revision files (default \"data\")")]
+			public string WorkDir { get; set; }
+
 			[Option("model", HelpText = "FW model version")]
 			public string ModelVersion { get; set; }
 

--- a/TestUtil/Options.cs
+++ b/TestUtil/Options.cs
@@ -27,7 +27,7 @@ namespace LfMerge.TestUtil
 			public string WorkDir { get; set; }
 
 			[Option("datadir", HelpText = "Where to store/find the split-up revision files (default \"data\")")]
-			public string WorkDir { get; set; }
+			public string DataDir { get; set; }
 
 			[Option("model", HelpText = "FW model version")]
 			public string ModelVersion { get; set; }

--- a/TestUtil/Options.cs
+++ b/TestUtil/Options.cs
@@ -18,6 +18,7 @@ namespace LfMerge.TestUtil
 			protected CommonOptions(CommonOptions other)
 			{
 				WorkDir = other.WorkDir;
+				DataDir = other.DataDir;
 				ModelVersion = other.ModelVersion;
 				Project = other.Project;
 				Parent = other.Parent;

--- a/TestUtil/Program.cs
+++ b/TestUtil/Program.cs
@@ -21,6 +21,12 @@ namespace LfMerge.TestUtil
 			if (tuple.Item1 == null)
 				return;
 
+			var commonOptions = tuple.Item2 as Options.CommonOptions;
+			if (commonOptions?.DataDir != null)
+			{
+				Settings.DataDirName = commonOptions.DataDir;
+			}
+
 			var verb = tuple.Item1;
 
 			switch (verb)

--- a/build/LfMerge.AutomatedSRTests.dep
+++ b/build/LfMerge.AutomatedSRTests.dep
@@ -6,8 +6,8 @@
 Type=TeamCity
 Url=http://build.palaso.org
 
-[TC::ChorusTrusty64lfmergeCont]
-Name=chorus-trusty64-lfmerge Continuous
+[TC::ChorusLinux64lfmergeCont]
+Name=chorus-linux64-lfmerge Continuous
 RevisionName=lastSuccessful
 RevisionValue=latest.lastSuccessful
 Condition=Linux
@@ -15,24 +15,24 @@ Path=LibChorus.dll*=>lib/
 MercurialExtensions/**/*.py=>MercurialExtensions
 
 
-[TC::ChorusTrusty64lfmergeCont]
-Name=chorus-trusty64-lfmerge Continuous
+[TC::ChorusLinux64lfmergeCont]
+Name=chorus-linux64-lfmerge Continuous
 RevisionName=lastSuccessful
 RevisionValue=latest.lastSuccessful
 Condition=Linux32
 Path=Mercurial-i686.zip!**=>.
 
 
-[TC::ChorusTrusty64lfmergeCont]
-Name=chorus-trusty64-lfmerge Continuous
+[TC::ChorusLinux64lfmergeCont]
+Name=chorus-linux64-lfmerge Continuous
 RevisionName=lastSuccessful
 RevisionValue=latest.lastSuccessful
 Condition=Linux64
 Path=Mercurial-x86_64.zip!**=>.
 
 
-[TC::PalasoTrusty64lfmergeContinuous]
-Name=palaso-trusty64-lfmerge Continuous
+[TC::PalasoLinux64lfmergeContinuous]
+Name=palaso-linux64-lfmerge Continuous
 RevisionName=lastSuccessful
 RevisionValue=latest.lastSuccessful
 Condition=Linux


### PR DESCRIPTION
This makes it possible to have one set of data aimed at Mongo 2.4, and a different set of data aimed at Mongo 3.2, for example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/lfmerge-autosrtests/2)
<!-- Reviewable:end -->
